### PR TITLE
[ISSUE #5332]Remove DefaultMessageStore's private field printTimes that is never used (#5336)

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
@@ -47,7 +47,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.common.AbstractBrokerRunnable;
 import org.apache.rocketmq.common.BrokerConfig;
@@ -137,8 +136,6 @@ public class DefaultMessageStore implements MessageStore {
 
     private StoreCheckpoint storeCheckpoint;
     private TimerMessageStore timerMessageStore;
-
-    private AtomicLong printTimes = new AtomicLong(0);
 
     private final LinkedList<CommitLogDispatcher> dispatcherList;
 


### PR DESCRIPTION
* [ISSUE #5332]Remove DefaultMessageStore's private field printTimes that is never used

* Remove unused imports

Co-authored-by: Zhanhui Li <lizhanhui@apache.org>